### PR TITLE
Preview Imagenes and PDF Files

### DIFF
--- a/Sipcon.WebApp/Sipcon.WebApp.Client/Components/PreviewImageDialog.razor
+++ b/Sipcon.WebApp/Sipcon.WebApp.Client/Components/PreviewImageDialog.razor
@@ -1,0 +1,275 @@
+﻿@using Sipcon.WebApp.Client.Models
+@using Sipcon.WebApp.Client.Services
+@using Sipcon.WebApp.Client.Utils
+@using FluentValidation
+@using Gotho.BlazorPdf
+
+
+@inject IDialogService DialogService
+@inject UtilModuleActions ModuleActionsService
+@inject IAttachmentService AttachmentService
+@inject IJSRuntime JSRuntime
+
+
+@if (!_imageExtencion.Contains(_applicationName))
+{
+    <PdfViewer @ref="_pdfViewer" />
+}
+else
+{
+    <MudForm @ref="@form" >
+    
+        <MudDialog Class="blur dialog-background " ActionsClass="dialog-background-surface">
+            <DialogContent>
+                @* <MudContainer Class="blur dialog-background-title py-2 pt-2 pa-2">
+                    <MudCard>
+                        <MudCardHeader>
+                            <CardHeaderContent>
+                                <MudGrid Spacing="0" Justify="Justify.Center">
+                                    <MudItem xs="12" sm="4">
+                                        <div class="d-flex justify-left">
+                                        </div>
+                                    </MudItem>
+
+                                    <MudItem xs="12" sm="2">
+
+                                    </MudItem>
+                                    <MudItem xs="12" sm="6">
+                                        <div class="d-flex justify-right" style="justify-content: end;">
+                                            <MudButton OnClick="Cancel">Cancelar</MudButton>
+                                        </div>
+                                    </MudItem>
+                                </MudGrid>
+                            </CardHeaderContent>
+                        </MudCardHeader>
+                    </MudCard>
+                </MudContainer> *@
+
+                <MudContainer Class="dialog-background-surface py-2 pt-2 pa-2">
+                <MudGrid Spacing="1" Justify="Justify.Center">
+
+                    <MudItem xs="12" sm="12">
+                        <MudCard>
+                            <MudCardHeader>
+                                <CardHeaderContent>
+                                    @* <MudStack Row="true">
+                                        <MudIcon Icon="@Icons.Material.Filled.Preview" Color="Color.Info" Style="font-size: 3rem;"></MudIcon>
+                                            <MudText Typo="Typo.subtitle2">@Title</MudText>
+                                    </MudStack> *@
+
+                                </CardHeaderContent>
+                                <CardHeaderActions>
+
+                                </CardHeaderActions>
+                            </MudCardHeader>
+                            <MudCardContent Style="padding-top: 1px;">
+                                <div class="d-flex justify-center align-center" Style="height:350px;">
+                                    <MudImage ObjectFit="ObjectFit.Cover" ObjectPosition="@ImagePosition"
+                                                  Height="@(ImageHeight)" Width="@(ImageWidth)" 
+                                                  Src="@(_FileOpen)" Alt="Vista Previa Imagen"
+                                                  Elevation="25" Class="rounded-lg"/>
+                                </div>
+
+                                <MudChipSet T="string" CheckMark Class="mt-6">
+                                    <MudChip Text="Center" OnClick="@(() => SetImagePosition(ObjectPosition.Center))" SelectedColor="Color.Primary" Default="true" />
+                                    <MudChip Text="Top" OnClick="@(() => SetImagePosition(ObjectPosition.Top))" SelectedColor="Color.Primary" />
+                                    <MudChip Text="Bottom" OnClick="@(() => SetImagePosition(ObjectPosition.Bottom))" SelectedColor="Color.Primary" />
+                                    <MudChip Icon="@Icons.Material.Outlined.PhotoSizeSelectActual" IconColor="Color.Info" Text="Minimizar" OnClick="@(() => MinPreviewImage())" SelectedColor="Color.Primary" />
+                                    <MudChip Icon="@Icons.Material.Outlined.PhotoSizeSelectLarge" IconColor="Color.Info" Text="Maximizar" OnClick="@(() => MaxPreviewImage())" SelectedColor="Color.Primary" />
+                                    <MudChip Icon="@Icons.Material.Outlined.FileDownload" IconColor="Color.Info" Text="Descargar" OnClick="@(() => ClickExportAttachment())" SelectedColor="Color.Primary" />
+                                </MudChipSet>
+
+                            </MudCardContent>
+                        </MudCard>
+                    </MudItem>
+                </MudGrid>
+            </MudContainer>
+            </DialogContent>
+        </MudDialog>
+
+
+    </MudForm>
+
+}
+
+
+@* <NestedDialogCustom IsVisible="@_nestedVisible" Success="@_success"
+                    onCloseNested="() => _nestedVisible = false"
+                    ErrorMessage="@_nestedErrorMessage"
+                    Title="@("Vista Previa")" /> *@
+
+
+<style>
+    .blur {
+    backdrop-filter: blur(10px);
+    }
+
+    .dialog-background {
+    background-color: transparent;
+    }
+
+    .dialog-background-title {
+    background: rgb(from var(--mud-palette-info-lighten) r g b / 50%);
+    color: var(--mud-palette-white);
+    }
+
+    .dialog-background-surface {
+    background: rgb(from var(--mud-palette-surface) r g b / 75%);
+    }
+</style>
+
+@code {
+
+    [Inject] private UserSession Session { get; set; } = null!;
+
+
+    [CascadingParameter]
+    private IMudDialogInstance MudDialog { get; set; } = default!;
+
+    [Parameter] public string Title { get; set; } = string.Empty;
+    [Parameter] public string IdAttachment { get; set; } = string.Empty;
+    [Parameter] public string NameAttachment { get; set; } = string.Empty;
+
+    private MudForm? form;
+    private string _errorMessage = string.Empty;
+
+    private void Cancel() => MudDialog.Cancel();
+    ObjectPosition ImagePosition = ObjectPosition.Center;
+
+    public int ImageHeight { get; set; } = 350;
+    public int ImageWidth { get; set; } = 720;
+
+    private string _nestedErrorMessage = string.Empty;
+    bool _success = false;
+    private bool _nestedVisible;
+
+    private string? _FileOpen = string.Empty;
+    private string _applicationName = string.Empty;
+
+    List<string> _imageExtencion = new List<string>()
+    {
+        "image/jpeg", 
+        "image/png", 
+        "video/mp4"
+    };
+
+    void SetImagePosition(ObjectPosition value)
+    {
+        ImagePosition = value;
+    }
+
+    private async Task MaxPreviewImage()
+    {
+
+        ImageHeight = 390;
+        ImageWidth = 1060;
+    }
+
+
+    private async Task MinPreviewImage()
+    {
+
+        ImageHeight = 350;
+        ImageWidth = 720;
+    }
+
+    protected override async Task OnInitializedAsync()
+    {
+        await SetFormatImage();
+
+        await GetImagePreview();
+
+        await Task.Delay(50);
+        await Task.CompletedTask;
+
+    }
+
+    
+    public required PdfViewer _pdfViewer { get; set; }
+
+    private async Task SetFormatImage()
+    {
+
+        var fileExtension = Path.GetExtension(NameAttachment).ToLowerInvariant();
+        switch (fileExtension)
+        {
+            case ".jpg":
+            case ".jpeg":
+                _applicationName = "image/jpeg";
+                break;
+            case ".png":
+            case ".pneg":
+                _applicationName = "image/png";
+                break;
+            case ".mp4":
+                _applicationName = "video/mp4";
+                break;
+            case ".pdf":
+                _applicationName = "application/pdf";
+                break;
+            default:
+                _applicationName = "application/pdf";
+                break;
+        }
+
+        StateHasChanged();
+    }
+
+    private async Task GetImagePreview()
+    {
+        _FileOpen = "";
+        var fileUrl = "images/foton_planta.jpeg";
+        var serviceResponse = await AttachmentService.GetAttachment(Convert.ToInt32(IdAttachment), Session.UserId);
+        if (serviceResponse.Processed)
+        {
+            var base64File = Convert.ToBase64String(serviceResponse.Data.ToArray());
+
+            if (_applicationName == "application/pdf")
+            {
+                await _pdfViewer.LoadPdfAsync(base64File, "PDF Document Filename");
+            }
+            else
+            {
+                fileUrl = $"data:{_applicationName};base64,{base64File}";
+            
+            }
+            
+        }
+       
+        _FileOpen = fileUrl;
+       
+       
+        StateHasChanged();
+    }
+    
+    private async Task ClickExportAttachment()
+    {
+        var serviceResponse = await AttachmentService.GetAttachment(Convert.ToInt32(IdAttachment), Session.UserId);
+        if (serviceResponse.Processed)
+        {
+            _success = true;
+            _nestedErrorMessage = "";
+
+           
+            var base64File = Convert.ToBase64String(serviceResponse.Data.ToArray());
+            var fileUrl = $"data:{_applicationName};base64,{base64File}";
+            await JSRuntime.InvokeVoidAsync("downloadFile", fileUrl, NameAttachment);
+
+        }
+        else
+        {
+            _success = false;
+            _nestedErrorMessage = serviceResponse.Message ?? MessageEnum.ExportNotOK.GetStringValue();
+            OpenNested();
+
+        }
+    }
+
+    
+    private void OpenNested()
+    {
+        _nestedVisible = true;
+        StateHasChanged();
+    }
+
+}

--- a/Sipcon.WebApp/Sipcon.WebApp.Client/Models/ApiResponse.cs
+++ b/Sipcon.WebApp/Sipcon.WebApp.Client/Models/ApiResponse.cs
@@ -10,4 +10,14 @@ namespace Sipcon.WebApp.Client.Models
         public int Total { get; set; } = 0;
         public T Data { get; set; } = new T();
     }
+
+
+    public class ApiStreamResponse
+    {
+        public int Status { get; set; } = 200;
+        public bool Processed { get; set; } = true;
+        public string Message { get; set; } = string.Empty;
+        public int Total { get; set; } = 0;
+        public Stream? File { get; set; } = null;
+    }
 }

--- a/Sipcon.WebApp/Sipcon.WebApp.Client/Pages/FailReport/FailReportDetails.razor
+++ b/Sipcon.WebApp/Sipcon.WebApp.Client/Pages/FailReport/FailReportDetails.razor
@@ -571,7 +571,7 @@
                                     onChangeReportDetail="() => GetFailReport()">
             </FailReportDetailCustom>
         </MudTabPanel>
-        @* COMENTARIOS *@
+        @* MENSAJES *@
         <MudTabPanel Icon="@Icons.Material.Filled.Message" Text="MENSAJES" BadgeData="@(_comment.Count > 99 ? "99+" : _comment.Count().ToString())" BadgeColor="Color.Success">
             @* Messages *@
             <MudCard Elevation="1" Class="pa-1 mt-2">
@@ -686,7 +686,13 @@
                                 @foreach (var item in _attachment)
                                 {
                                         <MudItem xs="12" sm="4">
-                                            <MudText Typo="Typo.caption"><b><MudIcon Icon="@Icons.Custom.FileFormats.FileDocument" Color="Color.Inherit" Class="mr-2" />@item.FileName</b></MudText>
+                                            
+                                            <MudLink OnClick="() => ClickPreviewImage(item.Id, item.FileName)" Color="Color.Info">  
+                                                <MudText Typo="Typo.caption">        
+                                                    <MudIcon Icon="@Icons.Custom.FileFormats.FileDocument" Color="Color.Inherit" Class="mr-2" />@item.FileName
+                                                </MudText>        
+                                            </MudLink>  
+                                            
                                         </MudItem>
                                         <MudItem xs="12" sm="4">
                                             <MudText Typo="Typo.caption">@item.DateCreate!.Value.ToString("F", CultureInfo.GetCultureInfo("es-VE"))</MudText>
@@ -694,8 +700,16 @@
                                         <MudItem xs="12" sm="4">
                                             <div class="d-flex justify-left">
                                                 <MudStack Row="true">
-                                                    <MudIconButton Icon="@Icons.Material.Outlined.FileDownload" Class="mr-2" Color="Color.Info" Size="Size.Small" OnClick="() => ClickExportAttachment(item.Id, item.FileName)" />
-                                                    <MudIconButton Icon="@Icons.Material.Filled.Delete" Class="mr-2" Color="Color.Info" Size="Size.Small" OnClick="() => ClickDeleteAttachment(item.Id)"  />
+                                                    <MudTooltip Text="descargar">
+                                                        <MudIconButton Icon="@Icons.Material.Outlined.FileDownload" Class="mr-2" Color="Color.Info" Size="Size.Small" OnClick="() => ClickExportAttachment(item.Id, item.FileName)" />
+                                                    </MudTooltip>
+                                                    <MudTooltip Text="eliminar">
+                                                        <MudIconButton Icon="@Icons.Material.Filled.Delete" Class="mr-2" Color="Color.Info" Size="Size.Small" OnClick="() => ClickDeleteAttachment(item.Id)"  />
+                                                    </MudTooltip>
+                                                    <MudTooltip Text="vista previa">
+                                                        <MudIconButton Icon="@Icons.Material.Filled.Preview" Class="mr-2" Color="Color.Info" Size="Size.Small" OnClick="() => ClickPreviewImage(item.Id, item.FileName)"  />
+                                                    </MudTooltip>
+                                                    
                                                     
                                                 </MudStack>
                                             </div>
@@ -938,6 +952,18 @@
             await Task.CompletedTask;
             
         }
+    }
+
+    private async Task ClickPreviewImage(int IdAttachment, string FileName)
+    {
+           
+        DialogOptions options = new() { BackdropClick = false, MaxWidth = MaxWidth.Large, FullWidth = true, CloseButton = true, NoHeader = false };
+        var parameters = new DialogParameters<PreviewImageDialog> { { x => x.Title, "Vista Previa." } , { x => x.IdAttachment, IdAttachment.ToString() } , { x => x.NameAttachment, FileName } };
+        var dialog = await DialogService.ShowAsync<PreviewImageDialog>("Vista Previa.", parameters, options);
+
+        StateHasChanged();
+
+        await Task.CompletedTask;
     }
 
     private async Task ClickExportPdfSRG()

--- a/Sipcon.WebApp/Sipcon.WebApp.Client/Program.cs
+++ b/Sipcon.WebApp/Sipcon.WebApp.Client/Program.cs
@@ -38,6 +38,7 @@ builder.Services.AddMudServices();
 builder.Services.AddAuthorizationCore();
 builder.Services.AddCascadingAuthenticationState();
 builder.Services.AddAuthenticationStateDeserialization();
+builder.Services.AddBlazorPdfViewer();
 
 builder.Services.AddTransient<ISessionStorageService, SessionStorageRepository>();
 builder.Services.AddScoped<UserSession>();

--- a/Sipcon.WebApp/Sipcon.WebApp.Client/Repository/AttachmentRepository.cs
+++ b/Sipcon.WebApp/Sipcon.WebApp.Client/Repository/AttachmentRepository.cs
@@ -80,6 +80,39 @@
             return result;
         }
 
+        public async Task<ApiStreamResponse> GetAttachmentPreview(int IdAttachment, int IdUser)
+        {
+            ApiStreamResponse result;
+            try
+            {
+                var response = await _http.GetAsync($"api/Attachment/GetPreview?userId={IdUser}&attachmentId={IdAttachment}");
+
+                var fileContent = await response.Content.ReadAsStreamAsync();
+
+                result = (fileContent is null) ? new ApiStreamResponse()
+                {
+                    Processed = false,
+                    Message = "Error al Exportar Data."
+                } : new ApiStreamResponse()
+                {
+                    Processed = true,
+                    Message = "",
+                    File = fileContent
+                };
+
+            }
+            catch (Exception ex)
+            {
+                result = new ApiStreamResponse()
+                {
+                    Processed = false,
+                    Message = string.Concat("Ocurrió un error inesperado: ", ex.Message)
+                };
+            }
+
+            return result;
+        }
+
         public async Task<ApiResponse<List<ActionResult>>> CreateAttachment(int IdRecord, string ModuleName, int IdUser, MultipartFormDataContent FormData)
         {
             ApiResponse<List<ActionResult>>? result;

--- a/Sipcon.WebApp/Sipcon.WebApp.Client/Services/IAttachment.cs
+++ b/Sipcon.WebApp/Sipcon.WebApp.Client/Services/IAttachment.cs
@@ -7,6 +7,7 @@
 
         public Task<ApiResponse<List<Attachment>>> GetAttachments(int IdRecord, string ModuleName);
         public Task<ApiResponse<List<byte>>> GetAttachment(int IdAttachment, int IdUser);
+        public Task<ApiStreamResponse> GetAttachmentPreview(int IdAttachment, int IdUser);
         public Task<ApiResponse<List<ActionResult>>> CreateAttachment(int IdRecord, string ModuleName, int IdUser, MultipartFormDataContent FormData);
         public Task<ApiResponse<ActionResult>> DeleteAttachment(int IdAttachment, int IdUser);
 

--- a/Sipcon.WebApp/Sipcon.WebApp.Client/Sipcon.WebApp.Client.csproj
+++ b/Sipcon.WebApp/Sipcon.WebApp.Client/Sipcon.WebApp.Client.csproj
@@ -12,9 +12,10 @@
 
   <ItemGroup>
     <PackageReference Include="FluentValidation" Version="12.1.1" />
+    <PackageReference Include="Gotho.BlazorPdf.MudBlazor" Version="2.2.0" />
     <PackageReference Include="Microsoft.AspNetCore.Components.Authorization" Version="10.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly" Version="10.0.2" />
-	  <PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.2" />  
+	<PackageReference Include="Microsoft.AspNetCore.Components.WebAssembly.Authentication" Version="10.0.2" />  
     <PackageReference Include="Microsoft.Extensions.Http" Version="10.0.2" />
     <PackageReference Include="MudBlazor" Version="8.15.0" />
     <PackageReference Include="System.IdentityModel.Tokens.Jwt" Version="8.15.0" />	

--- a/Sipcon.WebApp/Sipcon.WebApp/Components/App.razor
+++ b/Sipcon.WebApp/Sipcon.WebApp/Components/App.razor
@@ -8,6 +8,7 @@
     <base href="@AppSettingsHelper.GetAppSetting("pathBase")" />
     <link href="https://fonts.googleapis.com/css?family=Roboto:300,400,500,700&display=swap" rel="stylesheet" />
     <link href=@Assets["_content/MudBlazor/MudBlazor.min.css"] rel="stylesheet" />
+    <link href=@Assets["_content/Gotho.BlazorPdf/blazorpdf.min.css"] rel="stylesheet" />
     <link href=@Assets["css/site.css"] rel="stylesheet" />
     <link href=@Assets["css/chatbot.css"] rel="stylesheet" />
     <ImportMap />

--- a/Sipcon.WebApp/Sipcon.WebApp/Program.cs
+++ b/Sipcon.WebApp/Sipcon.WebApp/Program.cs
@@ -68,6 +68,8 @@ builder.Services.AddMudServices();
 
 builder.Services.AddAuthorization();
 builder.Services.AddCascadingAuthenticationState();
+builder.Services.AddBlazorPdfViewer();
+
 builder.Services.AddScoped<UserSession>();
 builder.Services.AddTransient<ISessionStorageService, SessionStorageRepository>();
 builder.Services.AddScoped<AuthenticationProviderJWT>();


### PR DESCRIPTION
Add attachment preview dialog with PDF/image support

Implemented PreviewImageDialog for viewing attachments (images, videos, PDFs) with zoom, position, and download controls. Integrated Gotho.BlazorPdf for PDF previews. Enhanced FailReportDetails to allow direct preview via clickable file names and preview icons. Updated attachment service/repository for streaming previews. Improved UI with tooltips and interactive elements. Registered necessary services and styles for PDF viewing.